### PR TITLE
[DOXIA-730] Update Asciidoctor Doxia Modules information

### DIFF
--- a/content/xdoc/references/index.xml
+++ b/content/xdoc/references/index.xml
@@ -76,13 +76,24 @@ under the License.
           </tr>
 
           <tr>
-            <td><a href="http://asciidoc.org/">AsciiDoc</a></td>
-            <td><a href="https://github.com/asciidoctor/asciidoctor-maven-plugin#maven-site-integration">Asciidoctor Maven Plugin</a></td>
+            <td><a href="https://asciidoctor.org/">AsciiDoc</a></td>
+            <td><a href="https://docs.asciidoctor.org/maven-tools/latest/site-integration/converter-module-setup-and-configuration/">Asciidoctor Converter Doxia Module</a></td>
             <td align="center"><img src="../images/icon_success_sml.gif" alt="Yes"/></td>
             <td align="center"><img src="../images/icon_error_sml.gif" alt="No"/></td>
             <td><code>asciidoc</code></td>
             <td><code>adoc</code>, <code>asciidoc</code></td>
-            <td><a href="https://github.com/asciidoctor/asciidoctor-maven-plugin#maven-site-integration"><code>asciidoctor-maven-plugin</code></a></td>
+            <td><a href="https://github.com/asciidoctor/asciidoctor-maven-plugin#maven-site-integration"><code>asciidoctor-converter-doxia-module</code></a></td>
+            <td><code>asciidoc</code></td>
+          </tr>
+
+          <tr>
+            <td><a href="https://asciidoctor.org/">AsciiDoc</a></td>
+            <td><a href="https://docs.asciidoctor.org/maven-tools/latest/site-integration/parser-module-setup-and-configuration/">Asciidoctor Parser Doxia Module</a></td>
+            <td align="center"><img src="../images/icon_success_sml.gif" alt="Yes"/></td>
+            <td align="center"><img src="../images/icon_success_sml.gif" alt="Yes"/></td>
+            <td><code>asciidoc</code></td>
+            <td><code>adoc</code>, <code>asciidoc</code></td>
+            <td><a href="https://github.com/asciidoctor/asciidoctor-maven-plugin#maven-site-integration"><code>asciidoctor-parser-doxia-module</code></a></td>
             <td><code>asciidoc</code></td>
           </tr>
 


### PR DESCRIPTION
* Replaced current 'asciidoctor-maven-plugin' with 'asciidoctor-converted-doxia-module' -> This is basically the same
* Addnew 'asciidoctor-parser-doxia-module' -> This new one, uses Asciidoctor to parse the document and then we use the Doxia Sink to generate content compatible with Fluido Skin.
* Updated URLs to point to the published documentation(s)