### PR TITLE
Drop backslash escapes that Markdown does not need

### DIFF
--- a/content/markdown/developers/index.md
+++ b/content/markdown/developers/index.md
@@ -24,7 +24,7 @@ date: 2008-03-02
 
 # Doxia Developers Centre
 
-This documentation centre is for those that are developing Doxia modules or macro\.
+This documentation centre is for those that are developing Doxia modules or macro.
 
 Currently you can find information on the following topics:
 

--- a/content/markdown/developers/macros.md
+++ b/content/markdown/developers/macros.md
@@ -24,7 +24,7 @@ date: 2008-03-02
 
 # Create a New Doxia Macro
 
-You need to add the following [plexus\-component\-metadata plugin](https://codehaus-plexus.github.io/plexus-containers/plexus-component-metadata/) configuration to generate the correct Plexus _component\.xml_ file from annotations for the project containing your macro:
+You need to add the following [plexus-component-metadata plugin](https://codehaus-plexus.github.io/plexus-containers/plexus-component-metadata/) configuration to generate the correct Plexus _component.xml_ file from annotations for the project containing your macro:
 
 ```unknown
 <project>

--- a/content/markdown/developers/modules.md.vm
+++ b/content/markdown/developers/modules.md.vm
@@ -24,7 +24,7 @@ date: 2008-03-02
 
 # Create a New Doxia Module
 
-First, the easiest way is to create a POM with _doxia\-modules_ as parent:
+First, the easiest way is to create a POM with _doxia-modules_ as parent:
 
 ```unknown
 <project>
@@ -41,7 +41,7 @@ First, the easiest way is to create a POM with _doxia\-modules_ as parent:
 </project>
 ```
 
-Secondly, you should implement some Doxia classes, depending on what features you want: parsing or generating markup\.
+Secondly, you should implement some Doxia classes, depending on what features you want: parsing or generating markup.
 
 ${esc.h}${esc.h} Parsing
 
@@ -60,9 +60,9 @@ ${esc.h}${esc.h} Parsing
     }
     ```
 
-    Depending on the type markup, extending `AbstractTextParser`, `AbstractXmlParser` or `XhtmlBaseParser` may give you more features\.
+    Depending on the type markup, extending `AbstractTextParser`, `AbstractXmlParser` or `XhtmlBaseParser` may give you more features.
 
-- _MyParseException_ class \(optional\)
+- _MyParseException_ class (optional)
 
     ```unknown
     import org.apache.maven.doxia.parser.ParseException;
@@ -102,7 +102,7 @@ ${esc.h}${esc.h} Generating
     }
     ```
 
-    Depending on the type markup, extending `AbstractTextSink`, `AbstractXmlSink` or `XhtmlBaseSink` may give you more features\.
+    Depending on the type markup, extending `AbstractTextSink`, `AbstractXmlSink` or `XhtmlBaseSink` may give you more features.
 
 - _MySinkFactory_ class
 
@@ -118,7 +118,7 @@ ${esc.h}${esc.h} Generating
     }
     ```
 
-    Depending on the type markup, extending `AbstractTextSinkFactory`, `AbstractXmlSinkFactory` or `AbstractBinarySinkFactory` may give you more features\.
+    Depending on the type markup, extending `AbstractTextSinkFactory`, `AbstractXmlSinkFactory` or `AbstractBinarySinkFactory` may give you more features.
 
 ${esc.h}${esc.h} <a id="References"></a>References
 

--- a/content/markdown/developers/sink.md
+++ b/content/markdown/developers/sink.md
@@ -27,7 +27,7 @@ date: 2008-03-02
 <!-- MACRO{toc|section=1|fromDepth=2|toDepth=2} -->
 ## <a id="Transforming_documents"></a>Transforming documents
 
-Doxia can be used to transform an arbitrary input document to any supported output format\. The following snippet shows how to use a Doxia _Parser_ to transform an apt file to html:
+Doxia can be used to transform an arbitrary input document to any supported output format. The following snippet shows how to use a Doxia _Parser_ to transform an apt file to html:
 
 ```unknown
   File userDir = new File( System.getProperty ( "user.dir" ) );
@@ -45,13 +45,13 @@ Doxia can be used to transform an arbitrary input document to any supported outp
   parser.parse( reader, sink );
 ```
 
-It is recommended that you use [Plexus](http://plexus.codehaus.org/) to look up the parser\. In principle you could instantiate the parser directly \( `Parser parser = new AptParser();` \) but then some special features like macros will not be available\.
+It is recommended that you use [Plexus](http://plexus.codehaus.org/) to look up the parser. In principle you could instantiate the parser directly ( `Parser parser = new AptParser();` ) but then some special features like macros will not be available.
 
-You could also use the [Doxia Converter Tool](http://maven.apache.org/doxia/doxia-tools/doxia-converter/index.html) to parse a given file/dir to another file/dir\.
+You could also use the [Doxia Converter Tool](http://maven.apache.org/doxia/doxia-tools/doxia-converter/index.html) to parse a given file/dir to another file/dir.
 
 ## <a id="Generating_documents"></a>Generating documents
 
-The snippet below gives a simple example of how to generate a document using the Doxia Sink API\.
+The snippet below gives a simple example of how to generate a document using the Doxia Sink API.
 
 ```unknown
     /**
@@ -102,11 +102,11 @@ The snippet below gives a simple example of how to generate a document using the
     }
 ```
 
-A more complete example that also shows the &apos;canonical&apos; order of events to use when generating a document, can be found in the Doxia [SinkTestDocument](./doxia/doxia-core/xref-test/org/apache/maven/doxia/sink/SinkTestDocument.html) class\.
+A more complete example that also shows the &apos;canonical&apos; order of events to use when generating a document, can be found in the Doxia [SinkTestDocument](./doxia/doxia-core/xref-test/org/apache/maven/doxia/sink/SinkTestDocument.html) class.
 
 ## <a id="Passing_attributes_to_Sink_events"></a>Passing attributes to Sink events
 
-A number of methods in the Sink API enable passing a set of attributes to many sink events\. A typical use case is:
+A number of methods in the Sink API enable passing a set of attributes to many sink events. A typical use case is:
 
 ```unknown
 SinkEventAttributeSet atts = new SinkEventAttributeSet();
@@ -115,11 +115,11 @@ atts.addAttribute( SinkEventAttributes.ALIGN, "center" );
 sink.paragraph( atts );
 ```
 
-The kind of attributes supported depends on the event and the sink implementation\. The sink API specifies a list of suggested attribute names that sinks are expected to recognize and parsers are expected to use when emitting events\.
+The kind of attributes supported depends on the event and the sink implementation. The sink API specifies a list of suggested attribute names that sinks are expected to recognize and parsers are expected to use when emitting events.
 
-## <a id="Avoid_sink.rawText.21"></a>Avoid sink\.rawText\!
+## <a id="Avoid_sink.rawText.21"></a>Avoid sink.rawText!
 
-In **Doxia 1\.0** it was a common practice to use sink\.rawText\(\) to generate elements that were not supported by the Sink API\. For example, the following snippet could be used to generate a styled HTML &lt;div&gt; block:
+In **Doxia 1\.0** it was a common practice to use sink.rawText() to generate elements that were not supported by the Sink API. For example, the following snippet could be used to generate a styled HTML &lt;div&gt; block:
 
 ```unknown
 sink.RawText( "<div style=\"cool\">" );
@@ -127,9 +127,9 @@ sink.text( "A text with a cool style." );
 sink.rawText( "</div>" );
 ```
 
-This has a major drawback however: it only works if the receiving Sink is a HTML Sink\. In other words, the above method will not work for target documents in any other format than HTML \(think of the FO Sink to generate a pdf, or a LaTeX sink,\.\.\.\)\.
+This has a major drawback however: it only works if the receiving Sink is a HTML Sink. In other words, the above method will not work for target documents in any other format than HTML (think of the FO Sink to generate a pdf, or a LaTeX sink,\.\.\.).
 
-In **Doxia 1\.1** a new method unknown\(\) was added to the Sink API that can be used to emit an arbitrary event without making special assumptions about the receiving Sink\. Depending on the parameters, a Sink may decide whether or not to process the event, emit it as raw text, as a comment, log it, etc\.
+In **Doxia 1\.1** a new method unknown() was added to the Sink API that can be used to emit an arbitrary event without making special assumptions about the receiving Sink. Depending on the parameters, a Sink may decide whether or not to process the event, emit it as raw text, as a comment, log it, etc.
 
 The correct way to generate the above &lt;div&gt; block is now:
 
@@ -142,9 +142,9 @@ sink.text( "A text with a cool style." );
 sink.unknown( "div", new Object[]{new Integer( HtmlMarkup.TAG_TYPE_END )}, null );
 ```
 
-Read the javadocs of the unknown\(\) method in the [Sink](./doxia/doxia-sink-api/apidocs/org/apache/maven/doxia/sink/Sink.html) interface and the [XhtmlbaseSink](./doxia/doxia-core/apidocs/org/apache/maven/doxia/sink/XhtmlBaseSink.html) for information on the method parameters\. Note that an arbitrary sink may be expected to ignore the unknown event completely\!
+Read the javadocs of the unknown() method in the [Sink](./doxia/doxia-sink-api/apidocs/org/apache/maven/doxia/sink/Sink.html) interface and the [XhtmlbaseSink](./doxia/doxia-core/apidocs/org/apache/maven/doxia/sink/XhtmlBaseSink.html) for information on the method parameters. Note that an arbitrary sink may be expected to ignore the unknown event completely!
 
-**In general, the rawText method should be avoided alltogether when emitting events into an arbitrary Sink\.**
+**In general, the rawText method should be avoided alltogether when emitting events into an arbitrary Sink.**
 
 ## <a id="How_to_inject_javascript_code_into_HTML"></a>How to inject javascript code into HTML
 

--- a/content/markdown/downloads.md
+++ b/content/markdown/downloads.md
@@ -26,4 +26,4 @@ date: 2009-03-02
 
 Releases of Maven Doxia are made available in both binary and source distributions. Individual JARs are also made available through Apache Maven repositories.
 
-Releases of all Doxia sub-project components \(currently Doxia, Doxia Sitetools and Doxia Tools\) may be downloaded from Maven Central in the usual way.
+Releases of all Doxia sub-project components (currently Doxia, Doxia Sitetools and Doxia Tools) may be downloaded from Maven Central in the usual way.

--- a/content/markdown/doxia-tools/index.md
+++ b/content/markdown/doxia-tools/index.md
@@ -27,7 +27,7 @@ date: 2023-01-08
 
 |**Doxia Tool**|**Version**|**Release Date**|**Description**|**Source Repository**|**Issue Tracking**|
 |:---|:---|:---|:---|:---|:---|
-|[ Doxia Converter](./doxia-converter/)|1\.3|2023\-01\-14|Convert a source document from one supported Doxia format to other supported Doxia format\.\.|[Git](https://gitbox.apache.org/repos/asf/maven-doxia-converter.git) / [GitHub](https://github.com/apache/maven-doxia-converter/)|[GitHub Issues](https://github.com/apache/maven-doxia-converter/issues) |
+|[ Doxia Converter](./doxia-converter/)|1\.3|2023-01-14|Convert a source document from one supported Doxia format to other supported Doxia format\.\.|[Git](https://gitbox.apache.org/repos/asf/maven-doxia-converter.git) / [GitHub](https://github.com/apache/maven-doxia-converter/)|[GitHub Issues](https://github.com/apache/maven-doxia-converter/issues) |
 
 ## Retired
 

--- a/content/markdown/index.md.vm
+++ b/content/markdown/index.md.vm
@@ -25,11 +25,11 @@ date: 2010-05-28
 
 # Maven Doxia
 
-Doxia is a content generation framework which aims to provide its users with powerful techniques for generating static and dynamic content: Doxia can be used in web\-based publishing context to generate static sites, in addition to being incorporated into dynamic content generation systems like blogs, wikis and content management systems\.
+Doxia is a content generation framework which aims to provide its users with powerful techniques for generating static and dynamic content: Doxia can be used in web-based publishing context to generate static sites, in addition to being incorporated into dynamic content generation systems like blogs, wikis and content management systems.
 
-Doxia supports [markup languages with simple syntaxes](./references/index.html)\. Lightweight markup languages are used by people who might be expected to read the document source as well as the rendered output\.
+Doxia supports [markup languages with simple syntaxes](./references/index.html). Lightweight markup languages are used by people who might be expected to read the document source as well as the rendered output.
 
-Doxia is used extensively by [Maven](http://maven.apache.org) and it powers the entire documentation system of Maven\. It gives Maven the ability to take any document that Doxia supports and output it any format\.
+Doxia is used extensively by [Maven](http://maven.apache.org) and it powers the entire documentation system of Maven. It gives Maven the ability to take any document that Doxia supports and output it any format.
 
 The current version of [Doxia base framework](./doxia/) is ${doxiaVersion}.
 
@@ -37,20 +37,20 @@ ${esc.h}${esc.h} Brief History
 
 <!-- {{{http://www.xmlmind.com/aptconvert.html}Aptconvert}}-->
 
-Based on the \(now defunct\) Aptconvert project developed by [Xmlmind](http://www.xmlmind.com/), Doxia was initially hosted by [Codehaus](http://codehaus.org/), to become a sub\-project of Maven early in 2006\.
+Based on the (now defunct) Aptconvert project developed by [Xmlmind](http://www.xmlmind.com/), Doxia was initially hosted by [Codehaus](http://codehaus.org/), to become a sub-project of Maven early in 2006\.
 
 ${esc.h}${esc.h} Main Features
 
 - Developed in Java
-- [Support of several markup formats](./references/index.html): APT \(Almost Plain Text\), Markdown, FML \(FAQ Markup Language\), XDoc \(popular in Apache land\), XHTML
+- [Support of several markup formats](./references/index.html): APT (Almost Plain Text), Markdown, FML (FAQ Markup Language), XDoc (popular in Apache land), XHTML
 - Easy to [learn the syntax of the supported markup formats](./modules/index.html)
 - Macro support
-- No need to have a corporate infrastructure \(like wiki\) to host your documentation
+- No need to have a corporate infrastructure (like wiki) to host your documentation
 - Extensible framework
 - [Site Tools extension](./doxia-sitetools/) for site or document rendering
 - [Additional Tools](./doxia-tools/) like [Doxia Converter](./doxia-tools/doxia-converter/index.html)
 
 ${esc.h}${esc.h} Doxia Reference Pages
 
-See [Doxia Markup Languages References](./references/index.html) page for a listing of all supported markups for each format\.
+See [Doxia Markup Languages References](./references/index.html) page for a listing of all supported markups for each format.
 

--- a/content/markdown/issues/index.md
+++ b/content/markdown/issues/index.md
@@ -24,7 +24,7 @@ date: 2009-03-02
 
 # Doxia Issues &amp; Gotchas
 
-This document collects some infos about specific issues and &apos;gotchas&apos; when working with Doxia\. Please check also the [Frequently Asked Questions](../faq.html)\.
+This document collects some infos about specific issues and &apos;gotchas&apos; when working with Doxia. Please check also the [Frequently Asked Questions](../faq.html).
 
 <!-- MACRO{toc|section=1|fromDepth=2|toDepth=2} -->
 ## <a id="Apt_anchors_and_links"></a>Apt anchors and links
@@ -41,13 +41,13 @@ and
 [WARNING] [Apt Parser] Modified invalid link: references/doxia-apt.html
 ```
 
-The reason is that in Apt, links to other source documents have to start with either `./` or `../` to distinguish them from internal links\. Please read the sections on [anchors](../references/doxia-apt.html#Anchors) and [links](../references/doxia-apt.html#Links) in our Apt guide\. Note in particular that internal links in Apt do **not** start with &apos;\#&apos;\.
+The reason is that in Apt, links to other source documents have to start with either `./` or `../` to distinguish them from internal links. Please read the sections on [anchors](../references/doxia-apt.html#Anchors) and [links](../references/doxia-apt.html#Links) in our Apt guide. Note in particular that internal links in Apt do **not** start with &apos;\#&apos;.
 
-**You should pay attention to these warnings since your links will most likely be broken\.** Unfortunately, the warning message cannot indicate the source file with the broken link \(see eg [MPDF\-11](https://issues.apache.org/jira/browse/MPDF-11)\), however, if you run in `DEBUG` mode, eg invoke maven with the `-X` switch, you can see which source document is being parsed when the warning is emitted\.
+**You should pay attention to these warnings since your links will most likely be broken.** Unfortunately, the warning message cannot indicate the source file with the broken link (see eg [MPDF-11](https://issues.apache.org/jira/browse/MPDF-11)), however, if you run in `DEBUG` mode, eg invoke maven with the `-X` switch, you can see which source document is being parsed when the warning is emitted.
 
 ## <a id="Figure_sink_events"></a>Figure sink events
 
-Doxia distinguishes between figures, which are block\-level elements, and images \(or icons\), which are in\-line elements\. For instance, the following sequence of sink events
+Doxia distinguishes between figures, which are block-level elements, and images (or icons), which are in-line elements. For instance, the following sequence of sink events
 
 ```unknown
 sink.figure( null );
@@ -70,9 +70,9 @@ should output the equivalent of this html snippet:
 </div>
 ```
 
-while the `figureGraphics( ... );` event alone can be used to generate an in\-line image, i\.e\. just the `<img>` tag in case of html\.
+while the `figureGraphics( ... );` event alone can be used to generate an in-line image, i.e. just the `<img>` tag in case of html.
 
-**Note** that we are using the forms that take a `SinkEventAttributeSet` above, even though we are just passing in null values\. The reason is that the alternative forms \(without `SinkEventAttributeSet`\) have a different behavior, which is kept for backward compatibility \(but the methods have been deprecated\)\. Using the same sequence of sink events as above, but omitting the `null` method parameters, will generate
+**Note** that we are using the forms that take a `SinkEventAttributeSet` above, even though we are just passing in null values. The reason is that the alternative forms (without `SinkEventAttributeSet`) have a different behavior, which is kept for backward compatibility (but the methods have been deprecated). Using the same sequence of sink events as above, but omitting the `null` method parameters, will generate
 
 ```unknown
 <img src="figure.png" alt="Figure caption"/>
@@ -80,5 +80,5 @@ while the `figureGraphics( ... );` event alone can be used to generate an in\-li
 
 ## <a id="Empty_Generated_Page"></a>Empty Generated Page
 
-After running `mvn site` using your Maven reporting plugin, you see that the generated page is empty\. Be sure that the the code calls `sink.close()`\.
+After running `mvn site` using your Maven reporting plugin, you see that the generated page is empty. Be sure that the the code calls `sink.close()`.
 

--- a/content/markdown/macros/index.md
+++ b/content/markdown/macros/index.md
@@ -24,11 +24,11 @@ date: 2009-03-02
 
 # Doxia Macros Guide
 
-The Doxia _Core_ includes macro mechanisms to facilitate the documentation writing\.
+The Doxia _Core_ includes macro mechanisms to facilitate the documentation writing.
 
-Macros are currently only supported for APT, Xdoc and FML formats\. Starting with Doxia 1\.7 \(maven\-site\-plugin 3\.5\), macros are also supported for XHTML and Markdown\. Macros are not \(and probably will never be\) supported by Confluence, Docbook and Twiki modules\.
+Macros are currently only supported for APT, Xdoc and FML formats. Starting with Doxia 1\.7 (maven-site-plugin 3\.5), macros are also supported for XHTML and Markdown. Macros are not (and probably will never be) supported by Confluence, Docbook and Twiki modules.
 
-A macro in an APT source file is a **non\-indented** line that looks like this:
+A macro in an APT source file is a **non-indented** line that looks like this:
 
 ```unknown
 %{macro_name|param1=value1|param2=value2|...}
@@ -55,7 +55,7 @@ As of Doxia 1\.7, the following macros are available:
 <!-- MACRO{toc|section=1|fromDepth=2|toDepth=2} -->
 ## <a id="Echo_Macro"></a>Echo Macro
 
-The _Echo_ macro is a very simple macro: it prints out the key and value of any supplied parameters\. For instance, in an APT file, you could write:
+The _Echo_ macro is a very simple macro: it prints out the key and value of any supplied parameters. For instance, in an APT file, you could write:
 
 ```unknown
 %{echo|param1=value1|param2=value2}
@@ -79,7 +79,7 @@ and it will output
 
 ## <a id="Snippet_Macro"></a>Snippet Macro
 
-The _Snippet_ macro is a very useful macro: it prints out the content of a file or a URL\. For instance, in an APT file, you could write:
+The _Snippet_ macro is a very useful macro: it prints out the content of a file or a URL. For instance, in an APT file, you could write:
 
 ```unknown
 %{snippet|id=myid|url=http://myserver/path/to/file.txt}
@@ -94,7 +94,7 @@ In a xdoc file, it will be:
 </macro>
 ```
 
-The `id` parameter is not required if you want to include the entire file\. If you want to include only a part of a file, you should add start and end demarcators: any line \(typically a comment\) that contains the strings &quot;`START`&quot;, &quot;`SNIPPET`&quot; and &quot;`myid`&quot; \(where `myid` is the `id` of the snippet\) is a start demarcator, and similarly &quot;`END SNIPPET myid`&quot; denotes the end of the snippet to include\. For example:
+The `id` parameter is not required if you want to include the entire file. If you want to include only a part of a file, you should add start and end demarcators: any line (typically a comment) that contains the strings &quot;`START`&quot;, &quot;`SNIPPET`&quot; and &quot;`myid`&quot; (where `myid` is the `id` of the snippet) is a start demarcator, and similarly &quot;`END SNIPPET myid`&quot; denotes the end of the snippet to include. For example:
 
 - Start and end snippets in a Java file
 
@@ -129,22 +129,22 @@ The `id` parameter is not required if you want to include the entire file\. If y
 
 |Parameter|Description|
 |:---|:---|
-|id|The id of the snippet to include\. If omitted the whole file/url will be included \(since Doxia 1\.1\)\.|
-|url|The path of the URL to include\.|
-|file|The path of the file to include \(since doxia\-1\.0\-alpha\-9\)\.|
-|verbatim|If the content should be output as verbatim escaped text\. If this is set to `false` then the content of the snippet will not be escaped\. This means that you can use it like Server\-Side Includes on a webserver\. Default value is `true`\.|
-|encoding|The encoding of the file to read \(since Doxia 1\.6\)\. If omitted the default JVM encoding will be used\.|
+|id|The id of the snippet to include. If omitted the whole file/url will be included (since Doxia 1\.1).|
+|url|The path of the URL to include.|
+|file|The path of the file to include (since doxia-1\.0-alpha-9).|
+|verbatim|If the content should be output as verbatim escaped text. If this is set to `false` then the content of the snippet will not be escaped. This means that you can use it like Server-Side Includes on a webserver. Default value is `true`.|
+|encoding|The encoding of the file to read (since Doxia 1\.6). If omitted the default JVM encoding will be used.|
 ## <a id="TOC_Macro"></a>TOC Macro
 
-The _TOC_ macro prints a Table Of Content of a document\. It is useful if you have several sections and subsections in your document\. For instance, in an APT file, you could write:
+The _TOC_ macro prints a Table Of Content of a document. It is useful if you have several sections and subsections in your document. For instance, in an APT file, you could write:
 
 ```unknown
 %{toc|section=2|fromDepth=2|toDepth=3}
 ```
 
-This displays a TOC for the second section in the document, including all subsections \(depth 2\) and sub\-subsections \(depth 3\)\.
+This displays a TOC for the second section in the document, including all subsections (depth 2) and sub-subsections (depth 3).
 
-**Note** that in Doxia, apt section titles are not implicit anchors \(see [Enhancements to the APT format](../references/doxia-apt.html)\), so you need to insert explicit anchors for links to work\!
+**Note** that in Doxia, apt section titles are not implicit anchors (see [Enhancements to the APT format](../references/doxia-apt.html)), so you need to insert explicit anchors for links to work!
 
 In a xdoc file, it will be:
 
@@ -158,21 +158,21 @@ In a xdoc file, it will be:
 
 |Parameter|Description|
 |:---|:---|
-|section|Display a TOC for the specified section only, or all sections if 0\. Positive int, not mandatory, 0 by default\.|
-|fromDepth|Minimum section depth to include in the TOC \(sections are depth 1, sub\-sections depth 2, etc\.\)\. Positive int, not mandatory, 0 by default\.|
-|toDepth|Maximum section depth to include in the TOC\. Positive int, not mandatory, 5 by default\.|
+|section|Display a TOC for the specified section only, or all sections if 0\. Positive int, not mandatory, 0 by default.|
+|fromDepth|Minimum section depth to include in the TOC (sections are depth 1, sub-sections depth 2, etc.). Positive int, not mandatory, 0 by default.|
+|toDepth|Maximum section depth to include in the TOC. Positive int, not mandatory, 5 by default.|
 
-From **Doxia 1\.1\.1** on you may also specify any of the html base attributes \(_i\.e\._ any of `id`, `class`, `style`, `lang`, `title`\) as parameters, e\.g\.:
+From **Doxia 1\.1\.1** on you may also specify any of the html base attributes (_i.e._ any of `id`, `class`, `style`, `lang`, `title`) as parameters, e.g.:
 
 ```unknown
 %{toc|class=myTOC}
 ```
 
-This can be used for styling the TOC via css\.
+This can be used for styling the TOC via css.
 
 ## <a id="SWF_Macro"></a>SWF Macro
 
-The _Swf_ macro prints Shockwave Flash assets in the documentation\. For instance, in an APT file, you could write:
+The _Swf_ macro prints Shockwave Flash assets in the documentation. For instance, in an APT file, you could write:
 
 ```unknown
 %{swf|src=swf/myfile.swf|id=MyMovie|width=600|height=200}
@@ -191,22 +191,22 @@ In a xdoc file, it will be:
 
 |Parameter|Description|
 |:---|:---|
-|src|Specifies the location \(URL\) of the movie to be loaded\.|
-|id|Identifies the Flash movie to the host environment \(a web browser, for example\) so that it can be referenced using a scripting language\.|
-|width|Specifies the width of the movie in either pixels or percentage of browser window\.|
-|height|Specifies the height of the movie in either pixels or percentage of browser window\.|
-|quality|Possible values: low, high, autolow, autohigh, best\.|
-|menu|True displays the full menu, allowing the user a variety of options to enhance or control playback\. False displays a menu that contains only the Settings option and the About Flash option\.|
-|loop|Possible values: true, false\. Specifies whether the movie repeats indefinitely or stops when it reaches the last frame\. The default value is true if this attribute is omitted\.|
-|play|Possible values: true, false\. Specifies whether the movie begins playing immediately on loading in the browser\. The default value is true if this attribute is omitted\.|
-|version|Specifies the width of the movie in either pixels or percentage of browser window\.|
-|allowScript|Specifies the width of the movie in either pixels or percentage of browser window\.|
+|src|Specifies the location (URL) of the movie to be loaded.|
+|id|Identifies the Flash movie to the host environment (a web browser, for example) so that it can be referenced using a scripting language.|
+|width|Specifies the width of the movie in either pixels or percentage of browser window.|
+|height|Specifies the height of the movie in either pixels or percentage of browser window.|
+|quality|Possible values: low, high, autolow, autohigh, best.|
+|menu|True displays the full menu, allowing the user a variety of options to enhance or control playback. False displays a menu that contains only the Settings option and the About Flash option.|
+|loop|Possible values: true, false. Specifies whether the movie repeats indefinitely or stops when it reaches the last frame. The default value is true if this attribute is omitted.|
+|play|Possible values: true, false. Specifies whether the movie begins playing immediately on loading in the browser. The default value is true if this attribute is omitted.|
+|version|Specifies the width of the movie in either pixels or percentage of browser window.|
+|allowScript|Specifies the width of the movie in either pixels or percentage of browser window.|
 
-For more information, see the [SWF Macro](./swf-macro.html) page\.
+For more information, see the [SWF Macro](./swf-macro.html) page.
 
 ## <a id="SSI_Macro"></a>SSI Macro
 
-Since Doxia 1\.7, the _SSI_ macro prints a server side include\. For instance, in an APT file, you could write:
+Since Doxia 1\.7, the _SSI_ macro prints a server side include. For instance, in an APT file, you could write:
 
 ```unknown
 %{ssi|function=include|file=included-file.html}
@@ -223,5 +223,5 @@ In a xdoc file, it will be:
 
 |Parameter|Description|
 |:---|:---|
-|function|The SSI function to insert\.|
-|_any_|Parameter that will be added to the SSI directive\.|
+|function|The SSI function to insert.|
+|_any_|Parameter that will be added to the SSI directive.|

--- a/content/markdown/macros/swf-macro.md
+++ b/content/markdown/macros/swf-macro.md
@@ -23,9 +23,9 @@ date: 2007-05-17
 <!-- under the License.-->
 # SWF Macro
 
-The SWF macro enables users of APT to put SWF \(Flash\) assets in their documentation\.
+The SWF macro enables users of APT to put SWF (Flash) assets in their documentation.
 
-Flash assets typically need to be wrappered in `object` and `embed` tags and can have a variety of parameters\. Below is a typical example:
+Flash assets typically need to be wrappered in `object` and `embed` tags and can have a variety of parameters. Below is a typical example:
 
 ```unknown
 <object classid='clsid:D27CDB6E-AE6D-11cf-96B8-444553540000'
@@ -41,13 +41,13 @@ Flash assets typically need to be wrappered in `object` and `embed` tags and can
 </object>
 ```
 
-In order to use a \*\.swf in your APT file, use the basic syntax:
+In order to use a \*.swf in your APT file, use the basic syntax:
 
 ```unknown
 %{swf|src=swf/myfile.swf|id=MyMovie|width=600|height=200}
 ```
 
-For which `src` is the required parameter\. Make sure to put your \*\.swf file into the **/resources** folder so that it will get copied to /target when running the `mvn site` task\.
+For which `src` is the required parameter. Make sure to put your \*.swf file into the **/resources** folder so that it will get copied to /target when running the `mvn site` task.
 
 You can use more advanced parameters to control the output, as per below:
 
@@ -57,11 +57,11 @@ You can use more advanced parameters to control the output, as per below:
 
 For a full listing of parameters and their values see the Adobe knowledge base:
 
-[http://www\.adobe\.com/cfusion/knowledgebase/index\.cfm?id=tn\_12701](http://www.adobe.com/cfusion/knowledgebase/index.cfm?id=tn_12701)
+[http://www.adobe.com/cfusion/knowledgebase/index.cfm?id=tn_12701](http://www.adobe.com/cfusion/knowledgebase/index.cfm?id=tn_12701)
 
 ## Parameters and Defaults
 
-Currently the following parameters are available through the macro\. If no value is placed within a parameter, the value will default to the following:
+Currently the following parameters are available through the macro. If no value is placed within a parameter, the value will default to the following:
 
 - id = &quot;swf&quot;
 - width = &quot;400&quot;
@@ -73,7 +73,7 @@ Currently the following parameters are available through the macro\. If no value
 - version = &quot;9,0,45,0&quot;
 - allowScript = &quot;sameDomain&quot;
 
-Note: There is some provided shorthand for versions, i\.e\. \- version=6 \- becomes version=6,0,29,0\.
+Note: There is some provided shorthand for versions, i.e. \- version=6 \- becomes version=6,0,29,0\.
 
-_TODO:_ only shorthand for 6 and 9 are functional\. Need to find standard long version for other types\.
+_TODO:_ only shorthand for 6 and 9 are functional. Need to find standard long version for other types.
 

--- a/content/markdown/modules/index.md
+++ b/content/markdown/modules/index.md
@@ -24,13 +24,13 @@ date: 2009-06-15
 
 # Doxia Modules Guide
 
-Doxia has several built\-in modules that support some standard markup languages, see the [References](../references/index.html) page for an overview\. The following is just a collection of reference links for the individual formats\.
+Doxia has several built-in modules that support some standard markup languages, see the [References](../references/index.html) page for an overview. The following is just a collection of reference links for the individual formats.
 
 <!-- MACRO{toc|section=1|fromDepth=2|toDepth=2} -->
 
 ## <a id="APT"></a>APT
 
-APT \(Almost Plain Text\) is a legacy simple text format.
+APT (Almost Plain Text) is a legacy simple text format.
 
 **References**:
 
@@ -38,7 +38,7 @@ APT \(Almost Plain Text\) is a legacy simple text format.
 
 ## <a id="FML"></a>FML
 
-FML \(FAQ Markup Language\) is a legacy FAQ markup language based on XHTML 1.0.
+FML (FAQ Markup Language) is a legacy FAQ markup language based on XHTML 1.0.
 
 **References**:
 

--- a/content/markdown/overview.md
+++ b/content/markdown/overview.md
@@ -34,7 +34,7 @@ The following figure represents the main components of the Doxia Framework.
 
 ## Sink API
 
-The _Sink_ interface is a generic markup language interface. It contains several methods that encapsulate common text syntax. A start tag is denoted by _xxxx\(\)_ method and a end of tag by _xxxx\_\(\)_ method. 
+The _Sink_ interface is a generic markup language interface. It contains several methods that encapsulate common text syntax. A start tag is denoted by _xxxx()_ method and a end of tag by _xxxx\_()_ method. 
 
 For instance, you could do things like: 
 
@@ -61,7 +61,7 @@ void parse( Reader source, Sink sink )
     throws ParseException; 
 ```
 
-The _ParseException_ class has the responsibility to catch all parsing exceptions. It provides an helper method, _getLineNumber\(\)_, which helps to find where an error occurred. 
+The _ParseException_ class has the responsibility to catch all parsing exceptions. It provides an helper method, _getLineNumber()_, which helps to find where an error occurred. 
 
 The _AbstractParser_ class is an abstract implementation of the _Parser_. It provides a macro mechanism to give dynamic functionalities for the parsing. For more information on macros, read the [Doxia Macro Guide](./macros/index.html). 
 

--- a/content/markdown/references/apt-format.md
+++ b/content/markdown/references/apt-format.md
@@ -26,30 +26,30 @@ date: 2009-03-02
 
 <!--~~~~~~~~~~~~-->
 
-APT stands for &quot;Almost Plain Text&quot;\. APT is a markup language that takes the hassle out of documentation writing by striving for simplicity\. Its syntax resembles plain\-text more than it resembles most other markup formats \(such as HTML\)\.
+APT stands for &quot;Almost Plain Text&quot;. APT is a markup language that takes the hassle out of documentation writing by striving for simplicity. Its syntax resembles plain-text more than it resembles most other markup formats (such as HTML).
 
-This document provides some examples of available APT formatting\.
+This document provides some examples of available APT formatting.
 
 ## Important Notice
 
-The information contained in this document corresponds to the original APT format as published by [Xmlmind](http://www.xmlmind.com/)\. In version 1\.1 Maven Doxia has applied several modifications to this original format, see this separate [document](./doxia-apt.html) for a detailed description\. Notable differences are highlighted below with a [\[Change\]](./doxia-apt.html) link\.
+The information contained in this document corresponds to the original APT format as published by [Xmlmind](http://www.xmlmind.com/). In version 1\.1 Maven Doxia has applied several modifications to this original format, see this separate [document](./doxia-apt.html) for a detailed description. Notable differences are highlighted below with a [\[Change\]](./doxia-apt.html) link.
 
-The following sections contain formatted text that demonstrates the use of APT to create paragraphs, headers, sections, lists, code samples, figures, tables, rules, breaks, and text level elements such as font styles, anchors, and special characters\. Boxes containing text in typewriter\-like font are examples of APT source\.
+The following sections contain formatted text that demonstrates the use of APT to create paragraphs, headers, sections, lists, code samples, figures, tables, rules, breaks, and text level elements such as font styles, anchors, and special characters. Boxes containing text in typewriter-like font are examples of APT source.
 
 ## <a id="Document_structure"></a>Document structure
 
 <!--~~~~~~~~~~~~~~~~~~~~-->
 
-A short APT document is contained in a single text file\. A longer document may be contained in a ordered list of text files\. For instance, first text file contains section 1, second text file contains section 2, and so on\.
+A short APT document is contained in a single text file. A longer document may be contained in a ordered list of text files. For instance, first text file contains section 1, second text file contains section 2, and so on.
 
 <dl>
 <dt>Note:</dt>
 <dd>Splitting the APT document in several text files on a section boundary is not mandatory. The split may occur anywhere. However doing so is recommended because a text file containing a section is by itself a valid APT document.</dd>
 </dl>
 
-A file contains a sequence of paragraphs and \`\`displays&apos;&apos; \(non paragraphs such as tables\) separated by open lines\.
+A file contains a sequence of paragraphs and \`\`displays&apos;&apos; (non paragraphs such as tables) separated by open lines.
 
-A paragraph is simply a sequence of consecutive text lines\.
+A paragraph is simply a sequence of consecutive text lines.
 
 ```unknown
   First line of first paragraph.
@@ -60,9 +60,9 @@ A paragraph is simply a sequence of consecutive text lines\.
   Line 2 of paragraph 2.
 ```
 
-The indentation of the first line of a paragraph is the main method used by an APT processor to recognize the type of the paragraph\. For example, a section title must not be indented at all\.
+The indentation of the first line of a paragraph is the main method used by an APT processor to recognize the type of the paragraph. For example, a section title must not be indented at all.
 
-A \`\`plain&apos;&apos; paragraph must be indented by a certain amount of space\. For example, a plain paragraph which is not contained in a list may be indented by two spaces\.
+A \`\`plain&apos;&apos; paragraph must be indented by a certain amount of space. For example, a plain paragraph which is not contained in a list may be indented by two spaces.
 
 ```unknown
 My section title (not indented).
@@ -70,7 +70,7 @@ My section title (not indented).
   My paragraph first line (indented by 2 spaces).
 ```
 
-Indentation is not rigid\. Any amount of space will do\. You don&apos;t even need to use a consistent indentation all over your document\. What really matters for an APT processor is whether the paragraph is not indented at all or, when inside a list, whether a paragraph is more or less indented than the first item of the list \(more about this later\)\.
+Indentation is not rigid. Any amount of space will do. You don&apos;t even need to use a consistent indentation all over your document. What really matters for an APT processor is whether the paragraph is not indented at all or, when inside a list, whether a paragraph is more or less indented than the first item of the list (more about this later).
 
 ```unknown
     First paragraph has its first line indented by four
@@ -94,7 +94,7 @@ Note that tabs are expanded with a tab width set to 8\.
 
 <!--~~~~~~~~-->
 
-A title is optional\. If used, it must appear as the first block of the document\.
+A title is optional. If used, it must appear as the first block of the document.
 
 ```unknown
             ------
@@ -105,15 +105,15 @@ A title is optional\. If used, it must appear as the first block of the document
              Date
 ```
 
-A title block is indented \(centering it is nicer\)\. It begins with a line containing at least 3 dashes \(`---`\)\.
+A title block is indented (centering it is nicer). It begins with a line containing at least 3 dashes (`---`).
 
-After the first `---` line, one or several consecutive lines of text \(implicit line break after each line\) specify the title of the document\.
+After the first `---` line, one or several consecutive lines of text (implicit line break after each line) specify the title of the document.
 
-This text may immediately be followed by another `---` line and one or several consecutive lines of text which specifies the author\(s\) of the document\. Each line represents an individual author\.
+This text may immediately be followed by another `---` line and one or several consecutive lines of text which specifies the author(s) of the document. Each line represents an individual author.
 
-The author sub\-block may optionally be followed by a date sub\-block using the same syntax\.
+The author sub-block may optionally be followed by a date sub-block using the same syntax.
 
-The following example is used for a document with an title and a date but with no declared author\.
+The following example is used for a document with an title and a date but with no declared author.
 
 ```unknown
             ------
@@ -124,19 +124,19 @@ The following example is used for a document with an title and a date but with n
             ------
 ```
 
-The last line is ignored\. It is just there to make the block nicer\.
+The last line is ignored. It is just there to make the block nicer.
 
-**Note**: the date has no specific format and will be parsed as string\. But we recommend to use the ISO\-8601 standard, since formatting a date varies around the world:
+**Note**: the date has no specific format and will be parsed as string. But we recommend to use the ISO-8601 standard, since formatting a date varies around the world:
 
-**YYYY\-MM\-DD**
+**YYYY-MM-DD**
 
-where **YYYY** is the year in the Gregorian calendar, **MM** is the month of the year between 01 \(January\) and 12 \(December\), and **DD** is the day of the month between 01 and 31\.
+where **YYYY** is the year in the Gregorian calendar, **MM** is the month of the year between 01 (January) and 12 (December), and **DD** is the day of the month between 01 and 31\.
 
 #### Paragraph
 
 <!--~~~~~~~~~~~-->
 
-Paragraphs other than the title block may appear before the first section\.
+Paragraphs other than the title block may appear before the first section.
 
 ```unknown
   Paragraph 1, line 1.
@@ -146,13 +146,13 @@ Paragraphs other than the title block may appear before the first section\.
   Paragraph 2, line 2.
 ```
 
-Paragraphs are indented\. They have already been described in the [Document structure](#Document_structure) section\.
+Paragraphs are indented. They have already been described in the [Document structure](#Document_structure) section.
 
 #### Section
 
 <!--~~~~~~~~~-->
 
-Sections are created by inserting section titles into the document\. Simple documents need not contain sections\.
+Sections are created by inserting section titles into the document. Simple documents need not contain sections.
 
 ```unknown
 Section title
@@ -166,7 +166,7 @@ Section title
 **** Sub-sub-sub-sub-section title
 ```
 
-Section titles are not indented\. A sub\-section title begins with one asterisk \(`*`\), a sub\-sub\-section title begins with two asterisks \(`**`\), and so forth up to four sub\-section levels\.
+Section titles are not indented. A sub-section title begins with one asterisk (`*`), a sub-sub-section title begins with two asterisks (`**`), and so forth up to four sub-section levels.
 
 #### List
 
@@ -186,13 +186,13 @@ Section titles are not indented\. A sub\-section title begins with one asterisk 
       * List item 3.
 ```
 
-List items are indented and begin with a asterisk \(`*`\)\.
+List items are indented and begin with a asterisk (`*`).
 
-Plain paragraphs more indented than the first list item are nested in that list\. Displays such as tables \(not indented\) are always nested in the current list\.
+Plain paragraphs more indented than the first list item are nested in that list. Displays such as tables (not indented) are always nested in the current list.
 
-To nest a list inside a list, indent its first item more than its parent list\. To end a list, add a paragraph or list item less indented than the current list\.
+To nest a list inside a list, indent its first item more than its parent list. To end a list, add a paragraph or list item less indented than the current list.
 
-Section titles always end a list\. Displays cannot end a list but the `[]` pseudo\-element may be used to force the end of a list\.
+Section titles always end a list. Displays cannot end a list but the `[]` pseudo-element may be used to force the end of a list.
 
 ```unknown
       * List item 3.
@@ -205,9 +205,9 @@ Verbatim text not contained in list item 3
 --------------------------------------------
 ```
 
-In the previous example, without the `[]`, the verbatim text \(not indented as all displays\) would have been contained in list item 3\.
+In the previous example, without the `[]`, the verbatim text (not indented as all displays) would have been contained in list item 3\.
 
-A single `[]` may be used to end several nested lists at the same time\. The indentation of `[]` may be used to specify exactly which lists should be ended\. Example:
+A single `[]` may be used to end several nested lists at the same time. The indentation of `[]` may be used to specify exactly which lists should be ended. Example:
 
 ```unknown
       * List item 1.
@@ -225,7 +225,7 @@ Verbatim text contained in list item 2, but not in sub-list item 2
 -------------------------------------------------------------------
 ```
 
-There are three kind of lists, the bulleted lists we have already described, the numbered lists and the definition lists\.
+There are three kind of lists, the bulleted lists we have already described, the numbered lists and the definition lists.
 
 ```unknown
       [[1]] Numbered item 1.
@@ -237,7 +237,7 @@ There are three kind of lists, the bulleted lists we have already described, the
       [[2]] Numbered item 2.
 ```
 
-A numbered list item begins with a label between two square brackets\. The label of the first item establishes the numbering scheme for the whole list:
+A numbered list item begins with a label between two square brackets. The label of the first item establishes the numbering scheme for the whole list:
 
 <dl>
 <dt><code>[[1]]</code></dt>
@@ -252,7 +252,7 @@ A numbered list item begins with a label between two square brackets\. The label
 <dd>Upper-roman numbering: I, II, III, IV, etc.</dd>
 </dl>
 
-The labels of the items other than the first one are ignored\. It is recommended to take the time to type the correct label for each item in order to keep the APT source document readable\.
+The labels of the items other than the first one are ignored. It is recommended to take the time to type the correct label for each item in order to keep the APT source document readable.
 
 ```unknown
       [Defined term 1] of definition list 2.
@@ -260,7 +260,7 @@ The labels of the items other than the first one are ignored\. It is recommended
       [Defined term 2] of definition list 2.
 ```
 
-A definition list item begins with a defined term: text between square brackets\.
+A definition list item begins with a defined term: text between square brackets.
 
 #### Verbatim text
 
@@ -275,11 +275,11 @@ Verbatim
 ----------------------------------------
 ```
 
-A verbatim block is not indented\. It begins with a non indented line containing at least 3 dashes \(`---`\)\. It ends with a similar line\.
+A verbatim block is not indented. It begins with a non indented line containing at least 3 dashes (`---`). It ends with a similar line.
 
-`+--` instead of `---` draws a box around verbatim text\.
+`+--` instead of `---` draws a box around verbatim text.
 
-Like in HTML, verbatim text is preformatted\. Unlike HTML, verbatim text is escaped: inside a verbatim display, markup is not interpreted by the APT processor\.
+Like in HTML, verbatim text is preformatted. Unlike HTML, verbatim text is escaped: inside a verbatim display, markup is not interpreted by the APT processor.
 
 #### Figure
 
@@ -289,25 +289,25 @@ Like in HTML, verbatim text is preformatted\. Unlike HTML, verbatim text is esca
 [Figure name] Figure caption
 ```
 
-A figure block is not indented\. It begins with the figure name between square brackets\. The figure name is optionally followed by some text: the figure caption\.
+A figure block is not indented. It begins with the figure name between square brackets. The figure name is optionally followed by some text: the figure caption.
 
-The figure name is the pathname of the file containing the figure but without an extension\. Example: if your figure is contained in `/home/joe/docs/mylogo.jpeg`, the figure name is `/home/joe/docs/mylogo`\. [\[Change\]](./doxia-apt.html#Figure_extensions)
+The figure name is the pathname of the file containing the figure but without an extension. Example: if your figure is contained in `/home/joe/docs/mylogo.jpeg`, the figure name is `/home/joe/docs/mylogo`. [\[Change\]](./doxia-apt.html#Figure_extensions)
 
-If the figure name comes from a relative pathname \(recommended practice\) rather than from an absolute pathname, this relative pathname is taken to be relative to the directory of the current APT document \(a la HTML\) rather than relative to the current working directory\.
+If the figure name comes from a relative pathname (recommended practice) rather than from an absolute pathname, this relative pathname is taken to be relative to the directory of the current APT document (a la HTML) rather than relative to the current working directory.
 
-Why not leave the file extension in the figure name? This is better explained by an example\. You need to convert an APT document to PostScript and your figure name is `/home/joe/docs/mylogo`\. An APT processor will first try to load `/home/joe/docs/mylogo.eps`\. When the desired format is not found, a APT processor tries to convert one of the existing formats\. In our example, the APT processor tries to convert `/home/joe/docs/mylogo.jpeg` to encapsulated PostScript\.
+Why not leave the file extension in the figure name? This is better explained by an example. You need to convert an APT document to PostScript and your figure name is `/home/joe/docs/mylogo`. An APT processor will first try to load `/home/joe/docs/mylogo.eps`. When the desired format is not found, a APT processor tries to convert one of the existing formats. In our example, the APT processor tries to convert `/home/joe/docs/mylogo.jpeg` to encapsulated PostScript.
 
 #### Table
 
 <!--~~~~~~~-->
 
-A table block is not indented\. It begins with a non indented line containing an asterisk and at least 2 dashes \(`*--`\)\. It ends with a similar line\.
+A table block is not indented. It begins with a non indented line containing an asterisk and at least 2 dashes (`*--`). It ends with a similar line.
 
-The first line is not only used to recognize a table but also to specify column justification\. In the following example,
+The first line is not only used to recognize a table but also to specify column justification. In the following example,
 
-- the second asterisk \(`*`\) is used to specify that column 1 is centered,
-- the plus sign \(`+`\) specifies that column 2 is left aligned,
-- the colon \(`:`\) specifies that column 3 is right aligned\.
+- the second asterisk (`*`) is used to specify that column 1 is centered,
+- the plus sign (`+`) specifies that column 2 is left aligned,
+- the colon (`:`) specifies that column 3 is right aligned.
 
 ```unknown
 *----------*--------------+----------------:
@@ -319,15 +319,15 @@ The first line is not only used to recognize a table but also to specify column 
 Table caption
 ```
 
-Rows are separated by a non indented line beginning with `*--`\.
+Rows are separated by a non indented line beginning with `*--`.
 
-An optional table caption \(non indented text\) may immediately follow the table\.
+An optional table caption (non indented text) may immediately follow the table.
 
-Rows may contain single line or multiple line cells\. Each line of cell text is separated from the adjacent cell by the pipe character \(`|`\)\. \(`|` may be used in the cell text if quoted: `\|`\.\)
+Rows may contain single line or multiple line cells. Each line of cell text is separated from the adjacent cell by the pipe character (`|`). (`|` may be used in the cell text if quoted: `\|`.)
 
-The last `|` is only used to make the table nicer\. The first `|` is not only used to make the table nicer, but also to specify that a grid is to be drawn around table cells\.
+The last `|` is only used to make the table nicer. The first `|` is not only used to make the table nicer, but also to specify that a grid is to be drawn around table cells.
 
-The following example shows a simple table with no grid and no caption\.
+The following example shows a simple table with no grid and no caption.
 
 ```unknown
 *-----*------*
@@ -345,7 +345,7 @@ The following example shows a simple table with no grid and no caption\.
 =====================
 ```
 
-A non indented line containing at least 3 equal signs \(`===`\)\.
+A non indented line containing at least 3 equal signs (`===`).
 
 #### Page break
 
@@ -355,7 +355,7 @@ A non indented line containing at least 3 equal signs \(`===`\)\.
 ^L
 ```
 
-A non indented line containing a single form feed character \(Control\-L\)\.
+A non indented line containing a single form feed character (Control-L).
 
 ### Text level elements
 
@@ -368,11 +368,11 @@ A non indented line containing a single form feed character \(Control\-L\)\.
   <Italic> font. <<Bold>> font. <<<Monospaced>>> font.
 ```
 
-Text between &lt; and &gt; must be rendered in italic\. Text between &lt;&lt; and &gt;&gt; must be rendered in bold\. Text between &lt;&lt;&lt; and &gt;&gt;&gt; must be rendered using a monospaced, typewriter\-like font\.
+Text between &lt; and &gt; must be rendered in italic. Text between &lt;&lt; and &gt;&gt; must be rendered in bold. Text between &lt;&lt;&lt; and &gt;&gt;&gt; must be rendered using a monospaced, typewriter-like font.
 
-Font elements may appear anywhere except inside other font elements\.
+Font elements may appear anywhere except inside other font elements.
 
-It is not recommended to use font elements inside titles, section titles, links and defined terms because an APT processor automatically applies appropriate font styles to these elements\.
+It is not recommended to use font elements inside titles, section titles, links and defined terms because an APT processor automatically applies appropriate font styles to these elements.
 
 #### Anchor and link
 
@@ -384,17 +384,17 @@ It is not recommended to use font elements inside titles, section titles, links 
   Link to {{{http://www.pixware.fr}Pixware home page}}.
 ```
 
-Text between curly braces \(`{}`\) specifies an anchor\. Text between double curly braces \(`{{}}`\) specifies a link\.
+Text between curly braces (`{}`) specifies an anchor. Text between double curly braces (`{{}}`) specifies a link.
 
-It is an error to create a link element that does not refer to an anchor of the same name\. The name of an anchor/link is its text with all non alphanumeric characters stripped\. [\[Change\]](./doxia-apt.html#Anchor_construction)
+It is an error to create a link element that does not refer to an anchor of the same name. The name of an anchor/link is its text with all non alphanumeric characters stripped. [\[Change\]](./doxia-apt.html#Anchor_construction)
 
-This rule does not apply to links to _external_ anchors\. Text beginning with `http:/`, `https:/`, `ftp:/`, `file:/`, `mailto:`, `../`, `./` \(`..\` and `.\` on Windows\) is recognized as an external anchor name\.
+This rule does not apply to links to _external_ anchors. Text beginning with `http:/`, `https:/`, `ftp:/`, `file:/`, `mailto:`, `../`, `./` (`..\` and `.\` on Windows) is recognized as an external anchor name.
 
-When the construct **\{\{\{**_name_**\}**_text_**\}\}** is used, the link text _text_ may differ from the link name _name_\.
+When the construct **\{\{\{**_name_**\}**_text_**\}\}** is used, the link text _text_ may differ from the link name _name_.
 
-Anchor/link elements may appear anywhere except inside other anchor/link elements\.
+Anchor/link elements may appear anywhere except inside other anchor/link elements.
 
-Section titles are implicitly defined anchors\. [\[Change\]](./doxia-apt.html#Anchors_for_section_titles)
+Section titles are implicitly defined anchors. [\[Change\]](./doxia-apt.html#Anchors_for_section_titles)
 
 #### Line break
 
@@ -405,9 +405,9 @@ Section titles are implicitly defined anchors\. [\[Change\]](./doxia-apt.html#An
   break.
 ```
 
-A backslash character \(`\`\) followed by a newline character\.
+A backslash character (`\`) followed by a newline character.
 
-Line breaks must not be used inside titles and tables \(which are line oriented blocks with implicit line breaks\)\.
+Line breaks must not be used inside titles and tables (which are line oriented blocks with implicit line breaks).
 
 #### Non breaking space
 
@@ -417,7 +417,7 @@ Line breaks must not be used inside titles and tables \(which are line oriented 
   Non\ breaking\ space.
 ```
 
-A backslash character \(`\`\) followed by a space character\.
+A backslash character (`\`) followed by a space character.
 
 #### Special character
 
@@ -427,17 +427,17 @@ A backslash character \(`\`\) followed by a space character\.
   Escaped special characters: \~, \=, \-, \+, \*, \[, \], \<, \>, \{, \}, \\.
 ```
 
-In certain contexts, these characters have a special meaning and therefore must be escaped if needed as is\. They are escaped by adding a backslash in front of them\. The backslash may itself be escaped by adding another backslash in front of it\.
+In certain contexts, these characters have a special meaning and therefore must be escaped if needed as is. They are escaped by adding a backslash in front of them. The backslash may itself be escaped by adding another backslash in front of it.
 
-Note that an asterisk, for example, needs to be escaped only if its begins a paragraph\. \(`*` has no special meaning in the middle of a paragraph\.\)
+Note that an asterisk, for example, needs to be escaped only if its begins a paragraph. (`*` has no special meaning in the middle of a paragraph.)
 
 ```unknown
   Copyright symbol: \251, \xA9, \u00a9.
 ```
 
-Latin\-1 characters \(whatever is the encoding of the APT document\) may be specified by their codes using a backslash followed by one to three octal digits or by using the `\x`_NN_ notation, where _NN_ are two hexadecimal digits\.
+Latin-1 characters (whatever is the encoding of the APT document) may be specified by their codes using a backslash followed by one to three octal digits or by using the `\x`_NN_ notation, where _NN_ are two hexadecimal digits.
 
-Unicode characters may be specified by their codes using the `\u`_NNNN_ notation, where _NNNN_ are four hexadecimal digits\.
+Unicode characters may be specified by their codes using the `\u`_NNNN_ notation, where _NNNN_ are four hexadecimal digits.
 
 #### Comment
 
@@ -447,9 +447,9 @@ Unicode characters may be specified by their codes using the `\u`_NNNN_ notation
 ~~Commented out.
 ```
 
-Text found after two tildes \(`~~`\) is ignored up to the end of line\.
+Text found after two tildes (`~~`) is ignored up to the end of line.
 
-A line of `~` is often used to \`\`underline&apos;&apos; section titles in order to make them stand out of other paragraphs\.
+A line of `~` is often used to \`\`underline&apos;&apos; section titles in order to make them stand out of other paragraphs.
 
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 

--- a/content/markdown/references/doxia-apt.md
+++ b/content/markdown/references/doxia-apt.md
@@ -27,14 +27,14 @@ date: 2013-04-06
 
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-In the following we provide a list of differences/enhancements to the original [APT](./apt-format.html) format that were incorporated in Doxia\. Apart from some exceptions, these differences are usually &apos;backwards\-compatible&apos;\. That is, any document that gets correctly processed by Aptconvert should also be a valid Doxia input file and lead to identical results when processed by a Doxia parser\.
+In the following we provide a list of differences/enhancements to the original [APT](./apt-format.html) format that were incorporated in Doxia. Apart from some exceptions, these differences are usually &apos;backwards-compatible&apos;. That is, any document that gets correctly processed by Aptconvert should also be a valid Doxia input file and lead to identical results when processed by a Doxia parser.
 
 <!-- MACRO{toc|section=1|fromDepth=2|toDepth=2} -->
 ## <a id="Paragraphs_in_list_items"></a>Paragraphs in list items
 
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-Contrary to the original APT parser, the Doxia APT parser does not put list items within paragraphs\. Eg, the example given in the APT guide:
+Contrary to the original APT parser, the Doxia APT parser does not put list items within paragraphs. Eg, the example given in the APT guide:
 
 ```unknown
     * List item 1.
@@ -79,11 +79,11 @@ produces:
 |Header 1|Header 2|
 |:---|:---|
 |Cell 1|Cell 2|
-## <a id="Multi-lines_cells_in_table"></a>Multi\-lines cells in table
+## <a id="Multi-lines_cells_in_table"></a>Multi-lines cells in table
 
 <!--~~~~~~~~~~~~~~~~~~~~-->
 
-Since 1\.1, multi\-lines cells are recognized with the character &apos;\\&apos; at the end of the cells:
+Since 1\.1, multi-lines cells are recognized with the character &apos;\\&apos; at the end of the cells:
 
 ```unknown
 *-----------+-----------+
@@ -105,7 +105,7 @@ produces:
 <!--~~~~~~~~~~~~~~~~~~~-->
 ### <a id="Anchors_for_section_titles"></a>Anchors for section titles
 
-Contrary to the original APT format, section titles are **not** implicitly defined anchors\. If you want an anchor for a section title you need to define it explicitly as such:
+Contrary to the original APT format, section titles are **not** implicitly defined anchors. If you want an anchor for a section title you need to define it explicitly as such:
 
 ```unknown
 * {Anchors for section titles}
@@ -113,30 +113,30 @@ Contrary to the original APT format, section titles are **not** implicitly defin
 
 ### <a id="Anchor_construction"></a>Anchor construction
 
-Contrary to the original APT format, an anchor/link is **not** its text with all non alphanumeric characters stripped\. Ideally, an anchor should be a valid Doxia id, ie it must begin with a letter \(\[A\-Za\-z\]\) and may be followed by any number of letters, digits \(\[0\-9\]\), hyphens \(&quot;\-&quot;\), underscores \(&quot;\_&quot;\), colons \(&quot;:&quot;\), and periods \(&quot;\.&quot;\)\. Any anchor that does not satisfy this pattern is transformed according to the following rules:
+Contrary to the original APT format, an anchor/link is **not** its text with all non alphanumeric characters stripped. Ideally, an anchor should be a valid Doxia id, ie it must begin with a letter (\[A-Za-z\]) and may be followed by any number of letters, digits (\[0-9\]), hyphens (&quot;\-&quot;), underscores (&quot;\_&quot;), colons (&quot;:&quot;), and periods (&quot;.&quot;). Any anchor that does not satisfy this pattern is transformed according to the following rules:
 
 - Any whitespace at the start and end is removed
 - If the first character is not a letter, prepend the letter &apos;a&apos;
 - Any spaces are replaced with an underscore &apos;\_&apos;
-- Any characters not matching the above pattern are stripped\.
+- Any characters not matching the above pattern are stripped.
 
-Note in particular that case is preserved in this conversation and that APT anchors and links are case\-sensitive\. So the anchor for the section title in the previous example would be `Anchors_for_section_titles`\.
+Note in particular that case is preserved in this conversation and that APT anchors and links are case-sensitive. So the anchor for the section title in the previous example would be `Anchors_for_section_titles`.
 
 ## <a id="Links"></a>Links
 
 <!--~~~~~~~~~~~~~~~~~~~-->
 
-In **Doxia\-1\.1** the notion of a &apos;_local_&apos; link was introduced in addition to _internal_ links and _external_ links\.
+In **Doxia-1\.1** the notion of a &apos;_local_&apos; link was introduced in addition to _internal_ links and _external_ links.
 
-- An **internal** link is a link to an anchor within the same source document\.
+- An **internal** link is a link to an anchor within the same source document.
 
-    In the APT format used by **Doxia\-1\.1**, internal links have to be valid Doxia ids, as specified in the anchors section above\.
+    In the APT format used by **Doxia-1\.1**, internal links have to be valid Doxia ids, as specified in the anchors section above.
 
-    Note in particular that internal links in APT do **not** start with &apos;\#&apos;\.
+    Note in particular that internal links in APT do **not** start with &apos;\#&apos;.
 
-- A **local** link is a link to another document within the same site\.
+- A **local** link is a link to another document within the same site.
 
-    In the APT format used by **Doxia\-1\.1**, local links **have to** start with either `./` or `../` to distinguish them from internal links\. E\.g\.,
+    In the APT format used by **Doxia-1\.1**, local links **have to** start with either `./` or `../` to distinguish them from internal links. E.g.,
 
     ```
       {{{doc/standalone.html}Standalone}}
@@ -154,14 +154,14 @@ In **Doxia\-1\.1** the notion of a &apos;_local_&apos; link was introduced in ad
       {{{standalone.html}Standalone}}
     ```
 
-    will be interpreted as an internal link \(dots are valid characters in anchor names\)\. Since you most likely meant to link to another source document, you should again prepend a &quot;\./&quot;\.
+    will be interpreted as an internal link (dots are valid characters in anchor names). Since you most likely meant to link to another source document, you should again prepend a &quot;./&quot;.
 
-- An **external** link is a link that is neither local nor internal\.
+- An **external** link is a link that is neither local nor internal.
 
-    An external link should be a valid [URI](http://www.ietf.org/rfc/rfc2396.txt)\.
+    An external link should be a valid [URI](http://www.ietf.org/rfc/rfc2396.txt).
 
-Anchors are always translated to a valid id, including escaping\. In some situation this can cause issues, especially when referring to a javadoc\-link\.  
-Since Doxia 1\.4 there is support for literal anchors, by using 2 hashed \(\#\#\) instead of 1\. This implies that the writer is responsible for using the right URL encoding\!
+Anchors are always translated to a valid id, including escaping. In some situation this can cause issues, especially when referring to a javadoc-link.  
+Since Doxia 1\.4 there is support for literal anchors, by using 2 hashed (\#\#) instead of 1\. This implies that the writer is responsible for using the right URL encoding!
 
 ```
   {{{../apidocs/groovyx/net/http/ParserRegistry.html##parseText(org.apache.http.HttpResponse)}ParserRegistry}}
@@ -171,7 +171,7 @@ Since Doxia 1\.4 there is support for literal anchors, by using 2 hashed \(\#\#\
 
 <!--~~~~~~~~~~~~~~~~~~~-->
 
-Contrary to the original APT format, a figure name has to be given fully **with** extension\. For instance:
+Contrary to the original APT format, a figure name has to be given fully **with** extension. For instance:
 
 ```unknown
 [/home/joe/docs/mylogo.jpeg] Figure caption

--- a/content/markdown/references/fml-format.md
+++ b/content/markdown/references/fml-format.md
@@ -27,7 +27,7 @@ under the License.
 
 ## Overview
 
-An &apos;fml&apos; \(FAQ Markup Language\) is an XML document conforming to a small and simple set of tags. The format was first used in the [Maven 1](http://maven.apache.org/maven-1.x/), version of the [FAQ plugin](http://maven.apache.org/maven-1.x/plugins/faq/). 
+An &apos;fml&apos; (FAQ Markup Language) is an XML document conforming to a small and simple set of tags. The format was first used in the [Maven 1](http://maven.apache.org/maven-1.x/), version of the [FAQ plugin](http://maven.apache.org/maven-1.x/plugins/faq/). 
 
 ## The FML format
 

--- a/content/markdown/references/index.md
+++ b/content/markdown/references/index.md
@@ -32,9 +32,9 @@ The following table gives an overview of the markup languages currently supporte
 
 - if a _Sink_ is available, it means you can generate output in this format.
 
-The source directory is the directory under which Maven expects source documents in this format \(e.g. `src/site/apt/` for Apt\), the file extension is the default file extension, and the parser id is gives the unique identifier that is used by plexus to lookup the corresponding component. 
+The source directory is the directory under which Maven expects source documents in this format (e.g. `src/site/apt/` for Apt), the file extension is the default file extension, and the parser id is gives the unique identifier that is used by plexus to lookup the corresponding component. 
 
-|Format|Short description|Parser<br />\(input\)|Sink<br />\(output\)|Source Directory|File Extension|Doxia Module|Parser Id|
+|Format|Short description|Parser<br />(input)|Sink<br />(output)|Source Directory|File Extension|Doxia Module|Parser Id|
 |---|---|---|---|---|---|---|---|
 |[Apt](./apt-format.html)|Almost Plain Text|![Yes](../images/icon_success_sml.gif)|![Yes](../images/icon_success_sml.gif)|`apt`|`apt`|[`doxia-module-apt`](../doxia/doxia-modules/doxia-module-apt/)|`apt`|
 |[AsciiDoc](https://asciidoctor.org/)|[Asciidoctor Converter Doxia Module](https://docs.asciidoctor.org/maven-tools/latest/site-integration/converter-module-setup-and-configuration/), only emits `Sink.rawText()`|![Yes](../images/icon_success_sml.gif)|![No](../images/icon_error_sml.gif)|`asciidoc`|`adoc`, `asciidoc`|[`asciidoctor-converter-doxia-module`](https://github.com/asciidoctor/asciidoctor-maven-plugin#maven-site-integration)|`asciidoc`|
@@ -70,7 +70,7 @@ The following table gives an overview of the formats which used to be supported 
 |Format|Short description|Doxia Module|Removed Since
 |---|---|---|
 |iText|iText PDF Library|[`doxia-module-itext`](../doxia-archives/doxia-1.11.1/doxia-modules/doxia-module-itext/)|2.0
-|FO|XSL formatting objects \(XSL-FO\)|[`doxia-module-fo`](../doxia-archives/doxia-1.11.1/doxia-modules/doxia-module-fo/)|2.0
+|FO|XSL formatting objects (XSL-FO)|[`doxia-module-fo`](../doxia-archives/doxia-1.11.1/doxia-modules/doxia-module-fo/)|2.0
 |LaTeX|LaTeX typesetting system|[`doxia-module-latex`](../doxia-archives/doxia-1.11.1/doxia-modules/doxia-module-latex/)|2.0
 |RTF|Microsoft Rich Text Format|[`doxia-module-rtf`](../doxia-archives/doxia-1.11.1/doxia-modules/doxia-module-rtf/)|2.0
 |Confluence|Confluence Enterprise Wiki|[`doxia-module-confluence`](../doxia-archives/doxia-1.11.1/doxia-modules/doxia-module-confluence/)|2.0

--- a/content/markdown/references/xdoc-format.md
+++ b/content/markdown/references/xdoc-format.md
@@ -108,7 +108,7 @@ code line 2
 <a id="Additional_sectioning"></a> 
 ## Additional sectioning
 
-Doxia will produce `<h2>` and `<h3>` headings for `<section>` and `<subsection>` elements, respectively. It is therefore perfectly valid to put some sub-headings \(`<h4>`, `<h5>`, `<h6>`\) inside a subsection. For instance, 
+Doxia will produce `<h2>` and `<h3>` headings for `<section>` and `<subsection>` elements, respectively. It is therefore perfectly valid to put some sub-headings (`<h4>`, `<h5>`, `<h6>`) inside a subsection. For instance, 
 
 ```unknown
 <h4>A subsubsection</h4>
@@ -134,7 +134,7 @@ The core doxia modules do **not** construct anchors from section/subsection name
 </section>
 ```
 
-or use an `id` attribute for section and subsections \(note that `id`&apos;s have to be unique within one xdoc source document\): 
+or use an `id` attribute for section and subsections (note that `id`&apos;s have to be unique within one xdoc source document): 
 
 ```unknown
 <section name="Section" id="Section1">
@@ -147,7 +147,7 @@ or use an `id` attribute for section and subsections \(note that `id`&apos;s hav
 
 **Note** that this differs from previous behavior, where anchors were constructed from section/subsection names, replacing special characters by underscores. This behavior presents two shortcomings: 
 
-- If two sections or subsections have identical names \(within one source document\), you will get an ambiguity when referencing them. Also the resulting html document will not be valid XHTML. For other output formats \(eg pdf\), it might even be impossible to generate the target document. 
+- If two sections or subsections have identical names (within one source document), you will get an ambiguity when referencing them. Also the resulting html document will not be valid XHTML. For other output formats (eg pdf), it might even be impossible to generate the target document. 
 
 - For long section titles, this leads to rather cumbersome anchor names. 
 

--- a/content/markdown/resources.md
+++ b/content/markdown/resources.md
@@ -33,9 +33,9 @@ date: 2009-03-02
 
 |Title|Publisher|Author|
 |:---|:---|:---|
-|[Quick and dirty typesetting with APT](https://www.linux.com/news/quick-and-dirty-typesetting-apt/)|linux\.com|Scott Nesbitt|
-|[Lightweight markup language](http://en.wikipedia.org/wiki/Lightweight_markup_language)|wikipedia\.org|?|
+|[Quick and dirty typesetting with APT](https://www.linux.com/news/quick-and-dirty-typesetting-apt/)|linux.com|Scott Nesbitt|
+|[Lightweight markup language](http://en.wikipedia.org/wiki/Lightweight_markup_language)|wikipedia.org|?|
 # Related External Projects
 
-- [XWiki](http://www.xwiki.org/) which uses Doxia in its [rendering](http://svn.xwiki.org/svnroot/xwiki/platform/core/trunk/xwiki-rendering/xwiki-rendering-parsers/xwiki-rendering-parser-doxia/)\.
-- [Mylyn WikiText](http://wiki.eclipse.org/Mylyn/Incubator/WikiText) \(originally known as Textile\-J\)\.
+- [XWiki](http://www.xwiki.org/) which uses Doxia in its [rendering](http://svn.xwiki.org/svnroot/xwiki/platform/core/trunk/xwiki-rendering/xwiki-rendering-parsers/xwiki-rendering-parser-doxia/).
+- [Mylyn WikiText](http://wiki.eclipse.org/Mylyn/Incubator/WikiText) (originally known as Textile-J).

--- a/content/markdown/scm.md
+++ b/content/markdown/scm.md
@@ -33,7 +33,7 @@ The sources for this site are available in a separate Git repository:
 
 |   |   |   |
 |---|---|---|
-|[Apache Maven Doxia website](/doxia/)|<pre><code><a href="https://gitbox.apache.org/repos/asf/maven-doxia-site.git" class="externalLink">https://gitbox.apache.org/repos/asf/maven-doxia-site.git</a></code></pre>|[\(GitHub mirror\)](https://github.com/apache/maven-doxia-site/)|
+|[Apache Maven Doxia website](/doxia/)|<pre><code><a href="https://gitbox.apache.org/repos/asf/maven-doxia-site.git" class="externalLink">https://gitbox.apache.org/repos/asf/maven-doxia-site.git</a></code></pre>|[(GitHub mirror)](https://github.com/apache/maven-doxia-site/)|
 
 ## Components in Git
 
@@ -41,7 +41,7 @@ The components in Git are:
 
 |   |   |   |
 |---|---|---|
-|[Apache Maven Doxia base](doxia/)|<pre><code><a href="https://gitbox.apache.org/repos/asf/maven-doxia.git" class="externalLink">https://gitbox.apache.org/repos/asf/maven-doxia.git</a></code></pre>|[\(GitHub mirror\)](https://github.com/apache/maven-doxia/)|
-|[Apache Maven Doxia Sitetools](doxia-sitetools/)|<pre><code><a href="https://gitbox.apache.org/repos/asf/maven-doxia-sitetools.git" class="externalLink">https://gitbox.apache.org/repos/asf/maven-doxia-sitetools.git</a></code></pre>|[\(GitHub mirror\)](https://github.com/apache/maven-doxia-sitetools/)|
+|[Apache Maven Doxia base](doxia/)|<pre><code><a href="https://gitbox.apache.org/repos/asf/maven-doxia.git" class="externalLink">https://gitbox.apache.org/repos/asf/maven-doxia.git</a></code></pre>|[(GitHub mirror)](https://github.com/apache/maven-doxia/)|
+|[Apache Maven Doxia Sitetools](doxia-sitetools/)|<pre><code><a href="https://gitbox.apache.org/repos/asf/maven-doxia-sitetools.git" class="externalLink">https://gitbox.apache.org/repos/asf/maven-doxia-sitetools.git</a></code></pre>|[(GitHub mirror)](https://github.com/apache/maven-doxia-sitetools/)|
 |Doxia Tools|
-|[Apache Maven Doxia Converter](doxia-tools/doxia-converter/)|<pre><code><a href="https://gitbox.apache.org/repos/asf/maven-doxia-converter.git" class="externalLink">https://gitbox.apache.org/repos/asf/maven-doxia-converter.git</a></code></pre>|[\(GitHub mirror\)](https://github.com/apache/maven-doxia-converter/)|
+|[Apache Maven Doxia Converter](doxia-tools/doxia-converter/)|<pre><code><a href="https://gitbox.apache.org/repos/asf/maven-doxia-converter.git" class="externalLink">https://gitbox.apache.org/repos/asf/maven-doxia-converter.git</a></code></pre>|[(GitHub mirror)](https://github.com/apache/maven-doxia-converter/)|


### PR DESCRIPTION
Pages converted from APT with an older `doxia-converter` carry a backslash in front of
punctuation that is not markup where it stands, for example `maven\-source\-plugin`,
`\(default\)` and `required\.`. The backslash renders as nothing; it only makes the source
harder to read and to edit, which was the point of moving to Markdown.

Only positions where the bare character can never be markup are touched: a hyphen,
underscore or asterisk between two word characters, a parenthesis, a full stop that
does not follow a digit, and an exclamation mark not followed by `[`.

Left alone deliberately:

* angle brackets, since `<escapeString>` really would be read as an HTML tag
* a full stop after a digit, so an ordered list marker cannot appear by accident
* a run of dots, because bare `...` is rendered as a single ellipsis character
* code spans, fenced blocks and link destinations

Verified by building the site before and after: every generated page is identical in
its visible text and in every link target.