### PR TITLE
Say what +-- actually does to a verbatim block

### DIFF
--- a/content/markdown/references/apt-format.md
+++ b/content/markdown/references/apt-format.md
@@ -277,7 +277,9 @@ Verbatim
 
 A verbatim block is not indented. It begins with a non indented line containing at least 3 dashes (`---`). It ends with a similar line.
 
-`+--` instead of `---` draws a box around verbatim text.
+`+--` instead of `---` marks the block as source code rather than plain preformatted text. The two produce different Sink events, and so different output: `+--` emits `verbatim` with the `source` decoration, which the XHTML5 Sink renders as `<pre><code>`, while `---` emits a plain `verbatim`, rendered as `<pre>`. Skins use that distinction to decide what to syntax highlight, so use `+--` for code and `---` for anything else, such as console output or a directory listing.
+
+Before Doxia 2 this was described as drawing a box around the text, and the attribute was named `BOXED` accordingly. It never really meant boxing, and the attribute was renamed to `SOURCE` in Doxia 2 to say what it is actually for.
 
 Like in HTML, verbatim text is preformatted. Unlike HTML, verbatim text is escaped: inside a verbatim display, markup is not interpreted by the APT processor.
 
@@ -512,10 +514,10 @@ Verbatim text not contained in list item 3
 
 +-------------------------------+
 Verbatim text
-                        in a box
+                     as source code
 +-------------------------------+
 
-  --- instead of +-- suppresses the box around verbatim text.
+  --- instead of +-- marks the block as plain text rather than source code.
 
 [Figure name] Figure caption
 


### PR DESCRIPTION
Part of apache/maven-doxia#876 (DOXIA-762), which points at this page: the APT reference documents `+--` versus `---` as boxed versus unboxed verbatim, and that is not what the two mean.

`+--` marks the block as source code. It emits `verbatim` with the `source` decoration, which the XHTML5 Sink renders as `<pre><code>`; `---` emits a plain `verbatim`, rendered as `<pre>`. Verified against `Xhtml5BaseSink.verbatim(SinkEventAttributes)` in Doxia 2.1.x, which switches on the decoration and only opens the `CODE` element for `source`. Skins use that distinction to decide what to syntax highlight, so the choice between the two is not cosmetic.

The "box" wording predates Doxia 2, where DOXIA-685 renamed the attribute from `BOXED` to `SOURCE` precisely because boxing was never what it meant.

So this replaces the sentence with what the two forms actually do, adds a line of guidance on which to use, and notes the rename for anyone coming from the old wording. The sample document further down repeated the same claim twice, so it is corrected there too.

Leaves the Markdown half of DOXIA-762 alone, since that belongs in the Markdown reference rather than here.