### PR TITLE
Build the site through the fail-fast job instead of a one-cell matrix

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -26,8 +26,6 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
-      ff-run: false
-      verify-goal: 'clean site'
-      os-matrix: '["ubuntu-latest"]'
-      jdk-matrix: '["17"]'
+      matrix-enabled: false
+      ff-goal: 'clean site'
 


### PR DESCRIPTION
`Verify` asks for a single `ubuntu-latest` / `jdk-17` matrix cell and switches the fail-fast job off. That combination leaves the matrix job ungated.

The shared workflow runs `setup-maven-version` only for a `push`, or for a `pull_request` whose head is a **fork**:

```yaml
if: >
  (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)) && ...
```

`verify` is guarded by:

```yaml
if: >
  (!cancelled()) && inputs.matrix-enabled && ( !inputs.ff-run || needs.fail-fast-build.result == 'success' ) && ...
```

With `ff-run: false` the second clause is true no matter what the other jobs did, and `!cancelled()` keeps a skipped dependency from propagating. So for a pull request opened from a branch **in this repository** `verify` still starts, and its matrix reads

```yaml
maven: ${{ fromJSON( needs.setup-maven-version.outputs.maven-matrix ) }}
```

from a job that never ran. Fork PRs are unaffected, which is why this has not shown up so far.

Asking for the fail-fast job and turning the matrix off expresses the same "one build" intent through the path that *is* gated on `setup-maven-version`. `ff-os` and `ff-jdk` already default to `ubuntu-latest` and `17`, so the build is unchanged; only `ff-goal` has to carry `clean site`.

`maven-parent`, `apache-parent` and `maven-shared-resources` configure their single-job builds the same way.

Alternatively this could be fixed centrally in `maven-gh-actions-shared` by adding `needs.setup-maven-version.result == 'success'` to `verify`'s condition, which would cover every caller that sets `ff-run: false`. Happy to open that instead or as well.