### PR TITLE
Build the site through the fail-fast job instead of a one-cell matrix

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -26,8 +26,7 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
-      ff-run: false
-      verify-goal: 'clean site'
-      os-matrix: '["ubuntu-latest"]'
-      jdk-matrix: '["17"]'
+      matrix-enabled: false
+      ff-goal: 'clean site'
+      ff-site-run: false
 


### PR DESCRIPTION
Reopening #71 with the missing `ff-site-run: false`, and with evidence that this is not theoretical.

## Every same-repo pull request fails today

`setup-maven-version` in the shared workflow runs for a `push`, or for a `pull_request` whose head is a **fork**. A pull request opened from a branch in this repository skips it, and `verify` should skip with it. With `ff-run: false` it does not:

```yaml
if: >
  (!cancelled()) && inputs.matrix-enabled && ( !inputs.ff-run || needs.fail-fast-build.result == 'success' ) && ...
```

`!inputs.ff-run` satisfies the second clause on its own, and `!cancelled()` is a status-check function, so the documented rule — *"if a job is skipped, all jobs that need it are skipped unless the jobs use a conditional expression that causes the job to continue"* — no longer applies. `verify` is attempted, and its matrix asks for

```yaml
maven: ${{ fromJSON( needs.setup-maven-version.outputs.maven-matrix ) }}
```

from a job that never ran, so the run dies during strategy evaluation.

Observed on the Dependabot pull requests, which are the only same-repo ones here:

| PR | head | `pull_request` run |
|---|---|---|
| #65, #66, #67 (Dependabot) | `apache:…` | **failed** |
| #68, #69, #70 | `slachiewicz:…` (fork) | passed |

[Run 29306636392](https://github.com/apache/maven-doxia-site/actions/runs/29306636392) shows the shape exactly: `setup-maven-version` skipped, `fail-fast-build` skipped **with its name never expanded**, and no `verify` job in the run at all.

## The change

Ask for the fail-fast job and turn the matrix off. `fail-fast-build` needs `setup-maven-version` and has no status function in its own condition, so it skips cleanly. `ff-os` and `ff-jdk` already default to `ubuntu-latest` and `17`, so the build is unchanged — the check-run name stays byte-identical, `Verify / ubuntu-latest jdk-17-zulu 3.10.0-rc-1`. Dropping `verify-goal` loses nothing since `verify` no longer runs.

`ff-site-run: false` is needed because the fail-fast job also runs `ff-site-goal` (`-DskipTests -P reporting compile site site:stage`), and `site:stage` cannot copy the symlinks the antrun execution creates in `target/site`:

```
[ERROR] maven-site-plugin:3.22.0:stage on project doxia-site:
        Error copying directory structure: Unknown file type: .../target/site/doxia-tools-archives
```

The pom already says as much — `<!-- no need for site:stage, use target/site -->` — and `ff-goal` runs `site` regardless, so the step is redundant here.

## Relationship to the shared workflow

apache/maven-gh-actions-shared#300 fixes the root cause for every consumer by requiring `needs.setup-maven-version.result == 'success'` in `verify`'s condition. `v4` carries the identical conditions, so it is affected too. This PR is still worth having on its own: it unblocks this repository now and drops a redundant site build.

`.asf.yaml` sets `protected_branches: master: { }` with no required status checks, so there is no check-name concern either way.