### PR TITLE
Answer the PDF FAQ with what Doxia can actually do now

### DIFF
--- a/content/fml/faq.fml
+++ b/content/fml/faq.fml
@@ -37,18 +37,14 @@ under the License.
       <question>How to export in PDF?</question>
       <answer>
         <p>
-          There are two modules available that can be used to generate pdf output: an
-          <a href="/doxia/doxia/doxia-modules/doxia-module-itext/">iText module</a>
-          that uses the
-          <a href="http://www.lowagie.com/iText/">iText</a> framework, and a
-          <a href="/doxia/doxia/doxia-modules/doxia-module-fo/">FO</a> module,
-          that can be used e.g. in conjunction with
-          <a href="http://xmlgraphics.apache.org/fop/">Apache FOP</a> to generate a pdf.
-          Unfortunately, the iText team has discontinued the XML to PDF functionalities, so probably
-          only the fo module is going to be supported in the future.
+          Doxia no longer generates PDF. The two modules that used to do it, the iText module and the
+          FO module, were removed in Doxia 2.0.0-M1, see
+          <a href="https://issues.apache.org/jira/browse/DOXIA-630">DOXIA-630</a>.
         </p>
         <p>
-          For Maven there is a <a href="/plugins/maven-pdf-plugin/">pdf plugin</a> available.
+          The Maven PDF Plugin, which built on those modules, was retired in March 2025. Its final
+          release, 1.6.2, is still resolvable from Maven Central, but it is not maintained and the
+          modules it depends on only exist in the unmaintained Doxia 1.x line.
         </p>
       </answer>
     </faq>


### PR DESCRIPTION
Follow-up cleanup from the `maven-pdf-plugin` retirement (final release 1.6.2 on 2025-03-04, repo archived under INFRA-26617).

The "How to export in PDF?" FAQ named three things, and all three are gone:

- the **iText module** and the **FO module** — both removed in Doxia 2.0.0-M1 by [DOXIA-630](https://issues.apache.org/jira/browse/DOXIA-630) ("Remove all deprecated modules", `ba9b17a4`);
- the **Maven PDF Plugin** — retired March 2025.

So the entry was three dead links deep, and the surviving advice ("probably only the fo module is going to be supported in the future") reads as a plan that was overtaken five years ago.

I kept it as a FAQ rather than deleting it, since "how do I get a PDF out of this" is still a reasonable question and the useful answer is now *you can't, and here is what happened*. The final `maven-pdf-plugin` release is named so that anyone whose build stopped working can find the trail without digging.

Note this is slightly wider than the retirement itself — fixing only the plugin sentence would have left the two removed modules recommended in the paragraph above it. Happy to narrow it if you would rather the module removal were its own change.

Paired with apache/maven-site#1635, which fixes the same recommendation in the Java report plugin guide. `xmllint` clean.

<sub>Drafted with Claude — please verify</sub>