### PR TITLE
Give each reference page a single top-level heading

### DIFF
--- a/content/markdown/references/fml-format.md
+++ b/content/markdown/references/fml-format.md
@@ -89,7 +89,7 @@ The following is a sample FML document:
 </faqs>
 ```
 
-# Validation
+## Validation
 
 Doxia is able to validate your fml files as described [here](../doxia/doxia-modules/doxia-module-fml/using-fml-xsd.html). 
 

--- a/content/markdown/references/xdoc-format.md
+++ b/content/markdown/references/xdoc-format.md
@@ -23,15 +23,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Content
+# The XDoc format
 
-<a id="Content"></a> 
+<a id="The_XDoc_format"></a> 
 
 <!-- MACRO{toc|fromDepth=1|toDepth=2} -->
 
-# The XDoc format
-
-<a id="The_XDoc_format"></a> <a id="Overview"></a> 
+<a id="Overview"></a> 
 ## Overview
 
 An &apos;xdoc&apos; is an XML document conforming to a small and simple set of tags. Xdoc was the primary documentation format in [Maven 1](http://maven.apache.org/maven-1.x/), Maven 2 largely replaced this by [Apt](apt-format.html), but xdoc is still supported. 
@@ -153,7 +151,7 @@ or use an `id` attribute for section and subsections (note that `id`&apos;s have
 
 If automatic anchor generation is desired for a particular output format, it should be implemented / overridden by the corresponding low-level Sink. 
 
-# Validation
+## Validation
 
 <a id="Validation"></a> 
 
@@ -162,7 +160,7 @@ Doxia is able to validate your xdoc files as described [here](../doxia/doxia-mod
 Here is a list of common mistakes to be aware of: 
 
 <a id="Dont_nest_block_level_elements"></a> 
-## Don&apos;t nest block level elements
+### Don&apos;t nest block level elements
 
 Wrong:
 
@@ -195,7 +193,7 @@ Correct:
 Typical block level elements are list elements, `<table>`, `<source>`, `<div>`, `<p>` and `<pre>`. 
 
 <a id="Put_inline_elements_inside_block_level_elements"></a> 
-## Put inline elements inside block level elements
+### Put inline elements inside block level elements
 
 Wrong:
 
@@ -218,12 +216,12 @@ Correct:
 Typical inline elements are `<a>`, `<strong>`, `<code>`, `<font>`, `<br>` and `<img>`. 
 
 <a id="Right_order_of_elements_in_properties"></a> 
-## Right order of elements in &lt;properties&gt;
+### Right order of elements in &lt;properties&gt;
 
 The `<title>` element has to come before `<author>`. 
 
 <a id="Dont_put_source_inside_paragraphs"></a> 
-## Don&apos;t put &lt;source&gt; inside paragraphs
+### Don&apos;t put &lt;source&gt; inside paragraphs
 
 Wrong:
 

--- a/content/markdown/resources.md
+++ b/content/markdown/resources.md
@@ -35,7 +35,7 @@ date: 2009-03-02
 |:---|:---|:---|
 |[Quick and dirty typesetting with APT](https://www.linux.com/news/quick-and-dirty-typesetting-apt/)|linux.com|Scott Nesbitt|
 |[Lightweight markup language](http://en.wikipedia.org/wiki/Lightweight_markup_language)|wikipedia.org|?|
-# Related External Projects
+## Related External Projects
 
 - [XWiki](http://www.xwiki.org/) which uses Doxia in its [rendering](http://svn.xwiki.org/svnroot/xwiki/platform/core/trunk/xwiki-rendering/xwiki-rendering-parsers/xwiki-rendering-parser-doxia/).
 - [Mylyn WikiText](http://wiki.eclipse.org/Mylyn/Incubator/WikiText) (originally known as Textile-J).


### PR DESCRIPTION
The xdoc, FML and resources pages carried two or three `h1` headings each, left over from the APT and FML conversions. Every other page on the site uses one, so screen readers and any tooling that keys off heading rank saw these three as several documents stitched together.

The xdoc page also opened with a `Content` heading above the document title, which put an entry in the table of contents pointing at the table of contents itself. Removing it leaves the title first and the TOC below it.

Trailing top-level sections (`Validation`, `Related External Projects`) become subsections. In the xdoc page the four `Validation` subsections drop a further level to stay beneath it, which takes them out of the TOC — the alternative, raising `toDepth` to 3, pulls in the `A subsubsection` sample heading, which has no anchor and renders as an empty link to `#null`. An empty link seemed the worse outcome, but say the word if you would rather keep those four entries and anchor the sample instead.

Verified: `mvn clean site` → no `href="#null"` anywhere, TOC keeps all 8 xdoc sections.

Independent of #75, which fixes stale content in other files; the two touch no common files. `references/index.md` has the same duplicate-`h1` shape and is corrected there.

*This change was created with AI assistance.*