### PR TITLE
Point the schema references at the published XSDs

### DIFF
--- a/content/markdown/references/fml-format.md
+++ b/content/markdown/references/fml-format.md
@@ -31,7 +31,7 @@ An &apos;fml&apos; (FAQ Markup Language) is an XML document conforming to a smal
 
 ## The FML format
 
-Below the root element `faqs` there are one or more `part` elements. Each `part` element has a `title` and contains one or more `faq` elements. Each `faq` element has a `question` and an `answer` element. The contents of `title`, `question` and `answer` are parsed with the [XDoc parser](xdoc-format.html). The full documentation is available at [here](../doxia/doxia-modules/doxia-module-fml/xsddoc/index.html). 
+Below the root element `faqs` there are one or more `part` elements. Each `part` element has a `title` and contains one or more `faq` elements. Each `faq` element has a `question` and an `answer` element. The contents of `title`, `question` and `answer` are parsed with the [XDoc parser](xdoc-format.html). The full documentation is available in the annotated [fml-1.0.1.xsd](https://maven.apache.org/xsd/fml-1.0.1.xsd) schema. 
 
 ## FML Sample
 

--- a/content/markdown/references/xdoc-format.md
+++ b/content/markdown/references/xdoc-format.md
@@ -41,7 +41,7 @@ The Maven 1 Xdoc plugin introduced a few additions to the Anakia format, they ar
 <a id="The_XDoc_xsd"></a> 
 ## The XDoc xsd
 
-The full documentation is available [here](../doxia/doxia-modules/doxia-module-xdoc/xsddoc/index.html). 
+The full documentation is available in the annotated [xdoc-2.0.xsd](https://maven.apache.org/xsd/xdoc-2.0.xsd) schema. 
 
 <a id="XDoc_Sample"></a> 
 ## XDoc Sample


### PR DESCRIPTION
The two "full documentation" links pointed at `xsddoc/index.html` pages generated by a `reporting` profile in doxia, which apache/maven-doxia is dropping — the generator (xsddoc 1.0) has been abandoned since 2003. The schemas themselves carry the same per-element documentation as inline annotations and are already served from `maven.apache.org/xsd/`, so they replace the generated pages directly.

Merging this before the doxia change avoids a window where the links are dead.

Verified: `mvn clean site` → no `xsddoc` string remains anywhere under `target/site`.

*This change was created with AI assistance.*